### PR TITLE
Have Agent & AgentRunner load in Boot-Path

### DIFF
--- a/opentracing-specialagent/pom.xml
+++ b/opentracing-specialagent/pom.xml
@@ -742,6 +742,7 @@
               <Main-Class>io.opentracing.contrib.specialagent.Agent</Main-Class>
               <Agent-Class>io.opentracing.contrib.specialagent.Agent</Agent-Class>
               <Premain-Class>io.opentracing.contrib.specialagent.Agent</Premain-Class>
+              <Boot-Class-Path>${project.artifactId}-${project.version}.jar</Boot-Class-Path>
               <Can-Redefine-Classes>true</Can-Redefine-Classes>
               <Can-Retransform-Classes>true</Can-Retransform-Classes>
             </manifestEntries>
@@ -752,6 +753,13 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Boot-Class-Path>${project.artifactId}-${project.version}-tests.jar</Boot-Class-Path>
+                </manifestEntries>
+              </archive>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/opentracing-specialagent/src/test/java/io/opentracing/contrib/specialagent/AgentRunner.java
+++ b/opentracing-specialagent/src/test/java/io/opentracing/contrib/specialagent/AgentRunner.java
@@ -509,7 +509,7 @@ public class AgentRunner extends BlockJUnit4ClassRunner {
 
     final Set<String> javaClassPath = Util.getJavaClassPath();
     if (logger.isLoggable(Level.FINEST))
-      logger.finest("java.class.path:\n  " + Util.toIndentedString(javaClassPath));
+      logger.finest("java.class.path:\n" + Util.toIndentedString(javaClassPath));
 
     final URL dependenciesUrl = Thread.currentThread().getContextClassLoader().getResource("dependencies.tgf");
     final String[] pluginPaths;
@@ -524,36 +524,22 @@ public class AgentRunner extends BlockJUnit4ClassRunner {
       pluginPaths = null;
     }
 
-    // BootClassLoader needs to have resolution of the following classes...
+    // These classes will be present in the Boot-Path...
     final Set<String> bootPaths = Util.getLocations(Tracer.class, NoopTracer.class, GlobalTracer.class, TracerResolver.class, Agent.class, AgentRunner.class);
 
     // Use the whole java.class.path for the forked process, because any class
     // on the classpath may be used in the implementation of the test method.
+    // Exclude JARs containing the classes in the Boot-Path.
     final String classpath = buildClassPath(javaClassPath, bootPaths);
     if (logger.isLoggable(Level.FINEST))
       logger.finest("ClassPath of forked process will be:\n  " + classpath.replace(File.pathSeparator, "\n  "));
-
-    // It is necessary to add the classpath locations of Tracer, NoopTracer,
-    // GlobalTracer, TracerResolver, Agent, and AgentRunner to the
-    // BootClassLoader, because:
-    // 1) These classes are required for the test to run, since the test
-    // directly references these classes, leaving just the SystemClassLoader
-    // and BootClassLoader as the only options.
-    // 2) The URLClassLoader must be detached from the SystemClassLoader, thus
-    // requiring the AgentRunner class to be loaded in the BootClassLoader,
-    // or otherwise Byteman will load the MockTracer in the BootClassLoader,
-    // while this code will load MockTracer in URLClassLoader.
-    final String bootClassPath = buildClassPath(bootPaths, null);
-    if (logger.isLoggable(Level.FINEST))
-      logger.finest("BootClassPath of forked process will be:\n" + Util.toIndentedString(bootPaths));
 
     if (logger.isLoggable(Level.FINEST))
       logger.finest("PluginsPath of forked process will be:\n" + Util.toIndentedString(pluginPaths));
 
     int i = -1;
-    final String[] args = new String[9 + (config.verbose() ? 1 : 0) + (config.disableLoadClasses() ? 1 : 0) + (loggingConfigFile != null ? 1 : 0)];
+    final String[] args = new String[8 + (config.verbose() ? 1 : 0) + (config.disableLoadClasses() ? 1 : 0) + (loggingConfigFile != null ? 1 : 0)];
     args[++i] = "java";
-    args[++i] = "-Xbootclasspath/a:" + bootClassPath;
     args[++i] = "-cp";
     args[++i] = classpath;
     args[++i] = "-javaagent:" + getAgentPath();

--- a/rules/opentracing-specialagent-camel/pom.xml
+++ b/rules/opentracing-specialagent-camel/pom.xml
@@ -67,5 +67,11 @@
       <version>1.2.15</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/rules/opentracing-specialagent-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorITest.java
+++ b/rules/opentracing-specialagent-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorITest.java
@@ -21,7 +21,7 @@ import io.opentracing.mock.MockTracer;
 @RunWith(AgentRunner.class)
 @AgentRunner.Config(debug=true, verbose=true)
 public class ExecutorITest extends AbstractConcurrentTest {
-	@Test
+  @Test
 	public void testExecute(final MockTracer tracer) throws InterruptedException {
     final CountDownLatch countDownLatch = new CountDownLatch(1);
     final Executor executor = Executors.newFixedThreadPool(10);


### PR DESCRIPTION
Prior to this update, the Agent was loaded in the System ClassLoader, which does not work for instrumentation of classes that belong to the Bootstrap ClassLoader. The AgentRunner had worked around this issue by explicitly setting the `-Xbootclasspath/a` argument, which is not necessary any longer.