### PR TITLE
Do not instrument NoPluggabilityServletContext

### DIFF
--- a/rules/opentracing-specialagent-web-servlet-filter/pom.xml
+++ b/rules/opentracing-specialagent-web-servlet-filter/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <version.org.apache.tomcat.embed>8.0.41</version.org.apache.tomcat.embed>
+    <version.org.apache.tomcat.embed>8.5.40</version.org.apache.tomcat.embed>
     <version.org.eclipse.jetty>9.3.15.v20161220</version.org.eclipse.jetty>
   </properties>
   <dependencies>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>3.1.0</version>
       <!-- If we add <optional>true</optional>, a fingerprint.bin will be
         generated, and the SpecialAgent will validate the APIs match in runtime.
         This may or may not be desirable, because it would then restrict this

--- a/rules/opentracing-specialagent-web-servlet-filter/src/main/java/io/opentracing/contrib/specialagent/webservletfilter/ServletContextAgentRule.java
+++ b/rules/opentracing-specialagent-web-servlet-filter/src/main/java/io/opentracing/contrib/specialagent/webservletfilter/ServletContextAgentRule.java
@@ -36,7 +36,9 @@ public class ServletContextAgentRule extends AgentRule {
         // Jetty is handled separately due to the (otherwise) need for tracking state of the ServletContext
         .and(not(nameStartsWith("org.eclipse.jetty")))
         // Similarly, ApplicationContextFacade causes trouble and it's enough to instrument ApplicationContext
-        .and(not(named("org.apache.catalina.core.ApplicationContextFacade"))))
+        .and(not(named("org.apache.catalina.core.ApplicationContextFacade")))
+        // Otherwise we are breaking Tomcat 8.5+
+        .and(not(named("org.apache.catalina.core.StandardContext$NoPluggabilityServletContext"))))
       .transform(new Transformer() {
         @Override
         public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {


### PR DESCRIPTION
I ran into issues when trying to make it work with Tomcat 8.5 and found that there's one more ServletContext type that should be not instrumented.

Also, I bumped Servlet spec to `3.1.0` (perhaps `4.0.1` should be considered?) as otherwise the instrumentation fails on missing method from 3.1 spec. The full stack trace with the latter problem was:

```
java.util.concurrent.ExecutionException: org.apache.catalina.LifecycleException: Failed to start component [StandardEngine[Tomcat].StandardHost[localhost].StandardContext[]]
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:942)
	at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:872)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1423)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1413)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.catalina.LifecycleException: Failed to start component [StandardEngine[Tomcat].StandardHost[localhost].StandardContext[]]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:167)
	... 6 more
Caused by: org.apache.catalina.LifecycleException: Failed to start component [Pipeline[StandardEngine[Tomcat].StandardHost[localhost].StandardContext[]]]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:167)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5146)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	... 6 more
Caused by: org.apache.catalina.LifecycleException: Failed to start component [org.apache.catalina.authenticator.NonLoginAuthenticator[]]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:167)
	at org.apache.catalina.core.StandardPipeline.startInternal(StandardPipeline.java:182)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	... 8 more
Caused by: java.lang.NoSuchMethodError: javax.servlet.ServletContext.getVirtualServerName()Ljava/lang/String;
	at org.apache.catalina.authenticator.AuthenticatorBase.startInternal(AuthenticatorBase.java:1181)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	... 10 more
```