### PR TITLE
upgrade jaeger to 0.0.2 with support of OpenTracing 0.32.0 API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>jaeger-client-bundle</artifactId>
-      <version>0.0.1</version>
+      <version>0.0.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
fix for #64 