### PR TITLE
Fix dependencies scope

### DIFF
--- a/rules/specialagent-lettuce/src/test/java/io/opentracing/contrib/specialagent/lettuce/LettuceTest.java
+++ b/rules/specialagent-lettuce/src/test/java/io/opentracing/contrib/specialagent/lettuce/LettuceTest.java
@@ -76,9 +76,9 @@ public class LettuceTest {
     final RedisCommands<String,String> commands2 = client.connect().sync();
     commands2.publish("channel", "msg");
 
-    client.shutdown();
-
     await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(4));
+
+    client.shutdown();
 
     final List<MockSpan> spans = tracer.finishedSpans();
     assertEquals(4, spans.size());

--- a/rules/specialagent-redisson/pom.xml
+++ b/rules/specialagent-redisson/pom.xml
@@ -41,12 +41,17 @@
           <groupId>org.redisson</groupId>
           <artifactId>redisson</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.opentracing.contrib</groupId>
+          <artifactId>opentracing-redis-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-redis-common</artifactId>
       <version>${opentracing.redis.version}</version>
+      <scope>provided</scope> <!-- It is added in lettuce rule -->
     </dependency>
     <dependency>
       <groupId>org.redisson</groupId>

--- a/rules/specialagent-spring-kafka/pom.xml
+++ b/rules/specialagent-spring-kafka/pom.xml
@@ -45,6 +45,7 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-kafka-client</artifactId>
       <version>0.1.3</version>
+      <scope>provided</scope> <!-- It is added in kafka-client rule -->
       <exclusions>
         <exclusion>
           <groupId>org.apache.kafka</groupId>

--- a/rules/specialagent-spring-webmvc/pom.xml
+++ b/rules/specialagent-spring-webmvc/pom.xml
@@ -38,6 +38,7 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-web-servlet-filter</artifactId>
       <version>0.4.0</version>
+      <scope>provided</scope> <!-- It is added in web-servlet-filter rule -->
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
I'm trying to fix next problems by this PR:
```
Caused by: java.lang.IllegalStateException: 
Dependencies already registered for opentracing-web-servlet-filter-0.4.0.jar 
Are there multiple rule JARs with dependencies.tgf referencing the same rule JAR? 
Offending JAR: opentracing-specialagent/specialagent-web-servlet-filter-1.2.1-SNAPSHOT.jar
```

Although I have another problem with this PR (in redisson app):
```
/projects/malafeev-sa-apps/redisson$ make run
java \
                -Dls.componentName=redisson \
                -Dls.collectorHost=collector.lightstep.com \
                -Dls.collectorProtocol=https \
                -Dls.collectorPort=443 \
                -Dls.accessToken=bla-bla-bla \
                -Dsa.tracer=lightstep \
                -cp target/redisson-1.0-SNAPSHOT.jar -javaagent:/Users/malafes/Downloads/opentracing-specialagent-1.2.1-SNAPSHOT.jar redisson.App
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
<><><><> ClassLoaderAgent.FindClass#exit 
java.lang.NoClassDefFoundError: io/opentracing/contrib/redis/common/TracingHelper
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:348)
        at io.opentracing.contrib.specialagent.RuleClassLoader$1.accept(RuleClassLoader.java:70)
        at io.opentracing.contrib.specialagent.RuleClassLoader$1.accept(RuleClassLoader.java:62)
        at io.opentracing.contrib.specialagent.RuleClassLoader.preLoad(RuleClassLoader.java:123)
        at io.opentracing.contrib.specialagent.SpecialAgent.findClass(SpecialAgent.java:663)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:384)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at io.netty.util.internal.logging.Log4JLoggerFactory.newInstance(Log4JLoggerFactory.java:38)
        at io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(InternalLoggerFactory.java:47)
        at io.netty.util.internal.logging.InternalLoggerFactory.getDefaultFactory(InternalLoggerFactory.java:67)
        at io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:93)
        at io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:86)
        at io.netty.channel.MultithreadEventLoopGroup.<clinit>(MultithreadEventLoopGroup.java:35)
        at org.redisson.connection.MasterSlaveConnectionManager.<init>(MasterSlaveConnectionManager.java:195)
        at org.redisson.connection.MasterSlaveConnectionManager.<init>(MasterSlaveConnectionManager.java:156)
        at org.redisson.connection.SingleConnectionManager.<init>(SingleConnectionManager.java:34)
        at org.redisson.config.ConfigSupport.createConnectionManager(ConfigSupport.java:229)
        at org.redisson.Redisson.<init>(Redisson.java:118)
        at org.redisson.Redisson.create(Redisson.java:157)
        at redisson.App.main(App.java:14)
Caused by: java.lang.ClassNotFoundException: io.opentracing.contrib.redis.common.TracingHelper
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 35 more

Exception in thread "main" java.lang.NoClassDefFoundError: io/opentracing/contrib/redis/common/TracingConfiguration$Builder
        at io.opentracing.contrib.specialagent.redisson.RedissonAgentIntercept.exit(RedissonAgentIntercept.java:27)
        at org.redisson.Redisson.create(Redisson.java:161)
        at redisson.App.main(App.java:14)
Caused by: java.lang.ClassNotFoundException: io.opentracing.contrib.redis.common.TracingConfiguration$Builder
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 3 more
```