### PR TITLE
explicit exit in KafkaClientITest due to embedded kafka/zookeper  processes may not exit

### DIFF
--- a/test/kafka-client-1.1.0/src/test/java/io/opentracing/contrib/specialagent/test/kafka/client/KafkaClientITest.java
+++ b/test/kafka-client-1.1.0/src/test/java/io/opentracing/contrib/specialagent/test/kafka/client/KafkaClientITest.java
@@ -74,6 +74,9 @@ public class KafkaClientITest {
 
     embeddedKafkaRule.after();
     TestUtil.checkSpan("java-kafka", 10);
+
+    // Embedded Kafka and Zookeeper processes may not exit
+    System.exit(0);
   }
 
   private static Producer<Long,String> createProducer(final EmbeddedKafkaRule embeddedKafkaRule) {


### PR DESCRIPTION
fix for #262