### PR TITLE
advice on filter strictly

### DIFF
--- a/rule/servlet/src/main/java/io/opentracing/contrib/specialagent/rule/servlet/FilterAgentRule.java
+++ b/rule/servlet/src/main/java/io/opentracing/contrib/specialagent/rule/servlet/FilterAgentRule.java
@@ -54,7 +54,7 @@ public class FilterAgentRule extends AgentRule {
         @Override
         public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
           return builder
-            .visit(Advice.to(FilterInitAdvice.class).on(named("init")))
+            .visit(Advice.to(FilterInitAdvice.class).on(named("init").and(takesArguments(1)).and(takesArgument(0, named("javax.servlet.FilterConfig")))))
             .visit(Advice.to(DoFilterEnter.class).on(named("doFilter")));
         }}),
       builder


### PR DESCRIPTION
if a class implements the interfaces javax.servlet.Filter and javax.servlet.http.HttpServlet both, the FilterInitAdvice will be invoked incorrectly on the "init" method of javax.servlet.http.HttpServlet, cause a class cast exception.

refer to ServletInitAdvice, add more condition to avoid the wrong visitor on filter init method.