### PR TITLE
Use File.separatorChar instead of hardcode '/'

### DIFF
--- a/opentracing-specialagent/src/main/java/io/opentracing/contrib/specialagent/SpecialAgentUtil.java
+++ b/opentracing-specialagent/src/main/java/io/opentracing/contrib/specialagent/SpecialAgentUtil.java
@@ -293,8 +293,8 @@ public final class SpecialAgentUtil {
     if (path.length() == 0)
       return path;
 
-    final boolean end = path.charAt(path.length() - 1) == '/';
-    final int start = end ? path.lastIndexOf('/', path.length() - 2) : path.lastIndexOf('/');
+    final boolean end = path.charAt(path.length() - 1) == File.separatorChar;
+    final int start = end ? path.lastIndexOf(File.separatorChar, path.length() - 2) : path.lastIndexOf(File.separatorChar);
     return start == -1 ? (end ? path.substring(0, path.length() - 1) : path) : end ? path.substring(start + 1, path.length() - 1) : path.substring(start + 1);
   }
 


### PR DESCRIPTION
Hard code '/' is not Windows environment friendly, in Windows platform, the application with specialagent cannot load tracer plugins properly.