### PR TITLE
fix deferring for spring-boot applications

### DIFF
--- a/rule/spring-boot/pom.xml
+++ b/rule/spring-boot/pom.xml
@@ -27,14 +27,108 @@
   <name>SpecialAgent Rule for Spring Boot</name>
   <properties>
     <version.spring.boot>2.0.0.RELEASE</version.spring.boot>
+    <version.reactor>3.2.12.RELEASE</version.reactor>
     <sa.plugin.name>spring:boot</sa.plugin.name>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring.boot}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-sleuth</artifactId>
+      <version>${version.spring.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jetty</artifactId>
+      <version>${version.spring.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web-services</artifactId>
+      <version>${version.spring.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <version>${version.spring.boot}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <version>${version.spring.boot}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <version>${version.spring.boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${version.spring.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <version>${version.reactor}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.brave</groupId>
+      <artifactId>brave-opentracing</artifactId>
+      <version>0.25.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>4.19.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.soap</groupId>
+      <artifactId>javax.xml.soap-api</artifactId>
+      <version>1.3.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.messaging.saaj</groupId>
+      <artifactId>saaj-impl</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring.boot}</version>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/rule/spring-boot/pom.xml
+++ b/rule/spring-boot/pom.xml
@@ -33,102 +33,10 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-      <version>${version.spring.boot}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-sleuth</artifactId>
-      <version>${version.spring.boot}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
-      <version>${version.spring.boot}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web-services</artifactId>
-      <version>${version.spring.boot}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
-      <version>${version.spring.boot}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <version>${version.spring.boot}</version>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <version>${version.spring.boot}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <version>${version.spring.boot}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-test</artifactId>
-      <version>${version.reactor}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing.brave</groupId>
-      <artifactId>brave-opentracing</artifactId>
-      <version>0.25.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin.reporter</groupId>
-      <artifactId>zipkin-reporter</artifactId>
-      <version>1.1.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave</artifactId>
-      <version>4.19.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.xml.soap</groupId>
-      <artifactId>javax.xml.soap-api</artifactId>
-      <version>1.3.8</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.messaging.saaj</groupId>
-      <artifactId>saaj-impl</artifactId>
-      <version>1.5.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring.boot}</version>
-      </plugin>
-    </plugins>
-  </build>
 </project>
 

--- a/rule/spring-boot/src/main/java/io/opentracing/contrib/specialagent/rule/spring/boot/SpringBootAgentRule.java
+++ b/rule/spring-boot/src/main/java/io/opentracing/contrib/specialagent/rule/spring/boot/SpringBootAgentRule.java
@@ -61,7 +61,7 @@ public class SpringBootAgentRule extends AgentRule {
       .transform(new Transformer() {
         @Override
         public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
-          return builder.visit(Advice.to(SpringBootAgentRule.class).on(named("getStartedMessage")));
+          return builder.visit(Advice.to(SpringBootAgentRule.class).on(named("logStarted")));
         }}));
   }
 

--- a/rule/spring-boot/src/main/java/io/opentracing/contrib/specialagent/rule/spring/boot/SpringBootAgentRule.java
+++ b/rule/spring-boot/src/main/java/io/opentracing/contrib/specialagent/rule/spring/boot/SpringBootAgentRule.java
@@ -37,13 +37,6 @@ public class SpringBootAgentRule extends AgentRule {
 
   @Override
   public boolean isDeferrable(final Instrumentation inst) {
-    // If `FrameworkServlet` is present, then Spring WebMVC is present, so rely on `SpringWebMvcAgentRule`
-    try {
-      Class.forName("org.springframework.web.servlet.FrameworkServlet", false, ClassLoader.getSystemClassLoader());
-      return false;
-    }
-    catch (final ClassNotFoundException e) {
-    }
 
     // Otherwise, check for the existence of `testClasses`
     for (int i = 0; i < testClasses.length; ++i) {
@@ -64,22 +57,17 @@ public class SpringBootAgentRule extends AgentRule {
   @Override
   public Iterable<? extends AgentBuilder> buildAgent(final AgentBuilder builder) throws Exception {
     return Arrays.asList(builder
-      .type(hasSuperType(named("org.springframework.context.event.ContextRefreshedEvent")))
+      .type(hasSuperType(named("org.springframework.boot.StartupInfoLogger")))
       .transform(new Transformer() {
         @Override
         public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
-          return builder.visit(Advice.to(SpringBootAgentRule.class).on(isConstructor()));
+          return builder.visit(Advice.to(SpringBootAgentRule.class).on(named("getStartedMessage")));
         }}));
   }
 
-  @Advice.OnMethodExit
+  @Advice.OnMethodEnter
   public static void exit(final @Advice.This Object thiz) throws ReflectiveOperationException {
     if (initialized)
-      return;
-
-    final Object applicationContext = thiz.getClass().getMethod("getSource").invoke(thiz);
-    final Object parent = applicationContext.getClass().getMethod("getParent").invoke(applicationContext);
-    if (parent != null)
       return;
 
     if (logger.isLoggable(Level.FINE))


### PR DESCRIPTION
this seems to fix deferring for spring-boot and works with two different applications. This works when I disable SpringWebMvc deferring as the latest change to SpringWebMvc seems to hook into Spring-Boot as well.
Regarding the changed to pom.xml: they are just copied over from an earlier version, because otherwise the tests don't succeed when executed through Maven.