### PR TITLE
customizable span

### DIFF
--- a/opentracing-specialagent-util/pom.xml
+++ b/opentracing-specialagent-util/pom.xml
@@ -53,5 +53,21 @@
       <groupId>junit</groupId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>2.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opentracing-specialagent-util/pom.xml
+++ b/opentracing-specialagent-util/pom.xml
@@ -28,6 +28,11 @@
   <url>https://github.com/opentracing-contrib/java-specialagent/tree/master/opentracing-specialagent-util</url>
   <dependencies>
     <dependency>
+        <groupId>com.grack</groupId>
+        <artifactId>nanojson</artifactId>
+        <version>1.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${version.maven}</version>

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableSpan.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableSpan.java
@@ -1,0 +1,123 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.Tag;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CustomizableSpan implements Span {
+  private final Span target;
+  private final SpanRules rules;
+  private SpanCustomizer customizer = new SpanCustomizer() {
+
+    @Override
+    public void addLogField(String key, Object value) {
+      target.log(Collections.singletonMap(key, value));
+    }
+
+    @Override
+    public void setTag(String key, Object value) {
+      if (value == null) {
+        target.setTag(key, (String) null);
+      } else if (value instanceof Number) {
+        target.setTag(key, (Number) value);
+      } else if (value instanceof Boolean) {
+        target.setTag(key, (Boolean) value);
+      } else {
+        target.setTag(key, value.toString());
+      }
+    }
+
+    @Override
+    public void setOperationName(String name) {
+      target.setOperationName(name);
+    }
+  };
+
+  public CustomizableSpan(Span target, SpanRules rules) {
+    this.target = target;
+    this.rules = rules;
+  }
+
+  @Override
+  public SpanContext context() {
+    return target.context();
+  }
+
+  @Override
+  public Span setTag(String key, String value) {
+    rules.setTag(key, value, customizer);
+    return this;
+  }
+
+  @Override
+  public Span setTag(String key, boolean value) {
+    rules.setTag(key, value, customizer);
+    return this;
+  }
+
+  @Override
+  public Span setTag(String key, Number value) {
+    rules.setTag(key, value, customizer);
+    return this;
+  }
+
+  @Override
+  public <T> Span setTag(Tag<T> tag, T value) {
+    rules.setTag(tag.getKey(), value, customizer);
+    return this;
+  }
+
+  @Override
+  public Span log(Map<String, ?> fields) {
+    rules.log(fields, new LogFieldCustomizer(0,customizer, target));
+    return this;
+  }
+
+  @Override
+  public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+    rules.log(fields, new LogFieldCustomizer(timestampMicroseconds,customizer, target));
+    return this;
+  }
+
+  @Override
+  public Span log(String event) {
+    rules.log(event, new LogEventCustomizer(0, customizer, target));
+    return this;
+  }
+
+  @Override
+  public Span log(long timestampMicroseconds, String event) {
+    rules.log(event, new LogEventCustomizer(timestampMicroseconds, customizer, target));
+    return this;
+  }
+
+  @Override
+  public Span setBaggageItem(String key, String value) {
+    target.setBaggageItem(key, value);
+    return this;
+  }
+
+  @Override
+  public String getBaggageItem(String key) {
+    return target.getBaggageItem(key);
+  }
+
+  @Override
+  public Span setOperationName(String operationName) {
+    rules.processOperationName(operationName, customizer);
+    return this;
+  }
+
+  @Override
+  public void finish() {
+    target.finish();
+  }
+
+  @Override
+  public void finish(long finishMicros) {
+    target.finish(finishMicros);
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableSpan.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableSpan.java
@@ -72,14 +72,18 @@ public class CustomizableSpan implements Span {
 
   @Override
   public Span log(Map<String, ?> fields) {
-    rules.log(fields, new LogFieldCustomizer(0,customizer, target));
+    rules.log(fields, logFieldCustomizer(0));
     return this;
   }
 
   @Override
   public Span log(long timestampMicroseconds, Map<String, ?> fields) {
-    rules.log(fields, new LogFieldCustomizer(timestampMicroseconds,customizer, target));
+    rules.log(fields, logFieldCustomizer(timestampMicroseconds));
     return this;
+  }
+
+  LogFieldCustomizer logFieldCustomizer(long timestampMicroseconds) {
+    return new LogFieldCustomizer(timestampMicroseconds, customizer, target);
   }
 
   @Override

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableSpanBuilder.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableSpanBuilder.java
@@ -1,0 +1,139 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class CustomizableSpanBuilder implements Tracer.SpanBuilder {
+  private final Tracer.SpanBuilder target;
+  private final SpanRules rules;
+  private List<Map<String, Object>> log;
+  private String operationName;
+  private SpanCustomizer customizer = new SpanCustomizer() {
+    @Override
+    public void setTag(String key, Object value) {
+      if (value == null) {
+        target.withTag(key, (String) null);
+      } else if (value instanceof Number) {
+        target.withTag(key, (Number) value);
+      } else if (value instanceof Boolean) {
+        target.withTag(key, (Boolean) value);
+      } else {
+        target.withTag(key, value.toString());
+      }
+    }
+
+    @Override
+    public void setOperationName(String name) {
+      operationName = name;
+    }
+
+    @Override
+    public void addLogField(String key, Object value) {
+      if (log == null) {
+        log = new ArrayList<>();
+      }
+      log.add(Collections.singletonMap(key, value));
+    }
+  };
+
+  public CustomizableSpanBuilder(Tracer.SpanBuilder target, SpanRules rules,
+                                 Map<String, Object> tags, List<Map<String, Object>> log) {
+    this.target = target;
+    this.rules = rules;
+    this.log = log;
+
+    if (tags != null) {
+      for (Map.Entry<String, Object> entry : tags.entrySet()) {
+        customizer.setTag(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  @Override
+  public Tracer.SpanBuilder asChildOf(SpanContext parent) {
+    target.asChildOf(parent);
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder asChildOf(Span parent) {
+    target.asChildOf(parent);
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+    target.addReference(referenceType, referencedContext);
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder ignoreActiveSpan() {
+    target.ignoreActiveSpan();
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder withTag(String key, String value) {
+    rules.setTag(key, value, customizer);
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder withTag(String key, boolean value) {
+    rules.setTag(key, value, customizer);
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder withTag(String key, Number value) {
+    rules.setTag(key, value, customizer);
+    return this;
+  }
+
+  @Override
+  public <T> Tracer.SpanBuilder withTag(Tag<T> tag, T value) {
+    rules.setTag(tag.getKey(), value, customizer);
+    return this;
+  }
+
+  @Override
+  public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+    target.withStartTimestamp(microseconds);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public Span startManual() {
+    return target.startManual();
+  }
+
+  @Override
+  public Span start() {
+    Span span = target.start();
+    if (log != null) {
+      for (Map<String, Object> fields : log) {
+        span.log(fields);
+      }
+    }
+    if (operationName != null) {
+      span.setOperationName(operationName);
+    }
+    return new CustomizableSpan(span, rules);
+  }
+
+  @Override
+  @Deprecated
+  public Scope startActive(boolean finishSpanOnClose) {
+    return target.startActive(finishSpanOnClose);
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracer.java
@@ -1,0 +1,54 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+public class CustomizableTracer implements Tracer {
+  private final Tracer target;
+  private final SpanRules rules;
+
+  public CustomizableTracer(Tracer target, SpanRules rules) {
+    this.target = target;
+    this.rules = rules;
+  }
+
+  @Override
+  public ScopeManager scopeManager() {
+    return target.scopeManager();
+  }
+
+  @Override
+  public Span activeSpan() {
+    return new CustomizableSpan(target.activeSpan(), rules);
+  }
+
+  @Override
+  public Scope activateSpan(Span span) {
+    return target.activateSpan(span);
+  }
+
+  @Override
+  public SpanBuilder buildSpan(String operationName) {
+    return new OperationNameCustomizer(operationName).buildSpan(target, rules);
+  }
+
+  @Override
+  public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+    target.inject(spanContext, format, carrier);
+  }
+
+  @Override
+  public <C> SpanContext extract(Format<C> format, C carrier) {
+    return target.extract(format, carrier);
+  }
+
+  @Override
+  public void close() {
+    target.close();
+  }
+}
+

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracer.java
@@ -33,7 +33,11 @@ public class CustomizableTracer implements Tracer {
 
   @Override
   public SpanBuilder buildSpan(String operationName) {
-    return new OperationNameCustomizer(operationName).buildSpan(target, rules);
+    return operationNameCustomizer(operationName).buildSpan(target, rules);
+  }
+
+  OperationNameCustomizer operationNameCustomizer(String operationName) {
+    return new OperationNameCustomizer(operationName);
   }
 
   @Override

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/LogEventCustomizer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/LogEventCustomizer.java
@@ -1,0 +1,38 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Span;
+
+public class LogEventCustomizer implements SpanCustomizer {
+  private final long timestampMicroseconds;
+  private final Span target;
+  private final SpanCustomizer base;
+
+  public LogEventCustomizer(long timestampMicroseconds, SpanCustomizer customizer, Span target) {
+    this.base = customizer;
+    this.timestampMicroseconds = timestampMicroseconds;
+    this.target = target;
+  }
+
+  @Override
+  public void addLogField(String key, Object value) {
+    log(value);
+  }
+
+  public void log(Object value) {
+    if (timestampMicroseconds > 0) {
+      target.log(timestampMicroseconds, value.toString());
+    } else {
+      target.log(value.toString());
+    }
+  }
+
+  @Override
+  public void setTag(String key, Object value) {
+    base.setTag(key, value);
+  }
+
+  @Override
+  public void setOperationName(String name) {
+    base.setOperationName(name);
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/LogFieldCustomizer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/LogFieldCustomizer.java
@@ -1,0 +1,51 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Span;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LogFieldCustomizer implements SpanCustomizer {
+  private final long timestampMicroseconds;
+  private final Span target;
+  private final SpanCustomizer base;
+  private Map<String, Object> fields;
+
+  public LogFieldCustomizer(long timestampMicroseconds, SpanCustomizer customizer, Span target) {
+    this.base = customizer;
+    this.timestampMicroseconds = timestampMicroseconds;
+    this.target = target;
+  }
+
+  @Override
+  public void addLogField(String key, Object value) {
+    if (fields == null) {
+      fields = new LinkedHashMap<>();
+    }
+    fields.put(key, value);
+  }
+
+  public void finish() {
+    if (fields != null) {
+      log(fields);
+    }
+  }
+
+  public void log(Map<String, ?> fields) {
+    if (timestampMicroseconds > 0) {
+      target.log(timestampMicroseconds, fields);
+    } else {
+      target.log(fields);
+    }
+  }
+
+  @Override
+  public void setTag(String key, Object value) {
+    base.setTag(key, value);
+  }
+
+  @Override
+  public void setOperationName(String name) {
+    base.setOperationName(name);
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/LogFieldCustomizer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/LogFieldCustomizer.java
@@ -9,7 +9,7 @@ public class LogFieldCustomizer implements SpanCustomizer {
   private final long timestampMicroseconds;
   private final Span target;
   private final SpanCustomizer base;
-  private Map<String, Object> fields;
+  Map<String, Object> fields;
 
   public LogFieldCustomizer(long timestampMicroseconds, SpanCustomizer customizer, Span target) {
     this.base = customizer;

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/OperationNameCustomizer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/OperationNameCustomizer.java
@@ -1,0 +1,47 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Tracer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OperationNameCustomizer implements SpanCustomizer {
+
+  private List<Map<String, Object>> log;
+  private Map<String, Object> tags;
+  private String operationName;
+
+  public OperationNameCustomizer(String operationName) {
+    this.operationName = operationName;
+  }
+
+  @Override
+  public void setTag(String key, Object value) {
+    if (tags == null) {
+      tags = new LinkedHashMap<>();
+    }
+    tags.put(key, value);
+  }
+
+  @Override
+  public void addLogField(String key, Object value) {
+    if (log == null) {
+      log = new ArrayList<>();
+    }
+    log.add(Collections.singletonMap(key, value));
+  }
+
+  @Override
+  public void setOperationName(String name) {
+    operationName = name;
+  }
+
+  public Tracer.SpanBuilder buildSpan(Tracer target, SpanRules rules) {
+    rules.processOperationName(operationName, this);
+
+    return new CustomizableSpanBuilder(target.buildSpan(operationName), rules, tags, log);
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/OperationNameCustomizer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/OperationNameCustomizer.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class OperationNameCustomizer implements SpanCustomizer {
 
   private List<Map<String, Object>> log;
-  private Map<String, Object> tags;
+  Map<String, Object> tags;
   private String operationName;
 
   public OperationNameCustomizer(String operationName) {

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/PlainSpanRuleMatcher.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/PlainSpanRuleMatcher.java
@@ -1,0 +1,37 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public class PlainSpanRuleMatcher implements SpanRuleMatcher {
+
+  private final Object expected;
+
+  public PlainSpanRuleMatcher(Object expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public SpanRuleMatch match(final Object value) {
+    if (!matchesValue(value)) {
+      return null;
+    }
+
+    return new SpanRuleMatch() {
+      @Override
+      public Object getValue(Object outputExpression) {
+        if (outputExpression != null) {
+          return outputExpression;
+        }
+        return value;
+      }
+    };
+  }
+
+  private boolean matchesValue(Object value) {
+    if (expected == null) {
+      return true;
+    }
+    if (expected instanceof Number && value instanceof Number) {
+      return ((Number) expected).doubleValue() == ((Number) value).doubleValue();
+    }
+    return expected.equals(value);
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/README.md
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/README.md
@@ -1,0 +1,199 @@
+The customizable tracer allows you to change the spans created by agent rules without having to modify the source code.
+
+All features are explained using the following use cases. These features can also be combined - even if this is not mentioned explicitly. 
+
+You will get a warning if the configuration has a logical error and the spans will not be modified.
+If you have configurations for multiple agent rules and only one of them has a configuration error,
+only the faulty configuration will be removed and the other continues to work as expected.   
+
+# Blacklisting
+
+Blacklisting is the most common use case to either reduce the traffic/noise - or to redact user information.
+
+## Blacklist a tag
+
+The following rule definition blacklists the `http.url` tag:
+
+```json
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "http.url"
+    }
+  ]
+}
+```
+
+If you only want to blacklist `http.url` if it equals `http://example.com`, add a `value`: 
+
+```json
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "http.url",
+      "value": "http://example.com"
+    }
+  ]
+}
+```
+
+If you want to blacklist all `http.url`s that start with `http://`, use a `valueRegex`:
+
+```json
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "http.url",
+      "valueRegex": "http://.*"
+    }
+  ]
+}
+```                           
+
+Note 
+1. The trailing `.*` is necessary, because the regular expression must match the entire tag value
+2. Use the [Java](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html) pattern syntax
+
+## Blacklist a log entry
+
+Blacklisting a log entry uses the same syntax as blacklisting a tag, except that the `type` is `log`.
+
+To blacklist a log event, use
+
+```json
+{
+  "jedis": [
+    {
+      "type": "log"
+    }
+  ]
+}
+```
+ 
+This would blacklist all log events (for jedis). 
+You can restrict the log events to be blacklisted using `value` or `valueRegex` (see above).
+
+To blacklist a single field from a log entry with fields, use 
+ 
+```json
+{
+  "jedis": [
+    {
+      "type": "log",
+      "key": "http.method"
+    },
+    {
+      "type": "log",
+      "key": "http.url"
+    }
+  ]
+}
+```                       
+
+Only the `http.method` and `http.url` fields will be removed from the log entry. If all fields from the log entry are blacklisted, the entire log entry is blacklisted as well.
+
+## Blacklist an operation name
+
+Every span must have an operation name, hence it's not possible to create a span without an operation name.
+
+However, it's also possible to change the operation name of a span after it has started - 
+and this call can be blacklisted. The result is the same as if 
+[setOperationName](https://javadoc.io/doc/io.opentracing/opentracing-api/0.20.2/io/opentracing/Span.html#setOperationName-java.lang.String-) had not been called.  
+
+```json
+{
+  "jedis": [
+    {
+      "type": "operationName"
+    }
+  ]
+}
+```
+
+This would blacklist all calls to `setOperationName` (in jedis). 
+You can restrict calls to be blacklisted using `value` or `valueRegex` (see above).
+
+# Advanced use cases
+
+The remaining use case cover advanced scenarios that go beyond blacklisting.
+
+## Transforming values
+
+If you want to strike a better balance between redacting user information and keeping observability, 
+you can redact specific parts of a value (tag, log or operationName).
+
+```json
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "db.statement",
+      "valueRegex": "(select * from user where first_name =).*",
+      "output": [
+        {
+          "type": "tag",
+          "value": "$1?"
+        }
+      ]
+    }
+  ]
+}
+```      
+
+## Multiple Outputs
+
+If you have a tag with a high cardinality (e.g. database statements without wildcards), 
+you might want to transform the value - but keep the original value somewhere else 
+(e.g. in a log statement which is not indexed). 
+
+```json
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "db.statement",
+      "valueRegex": "(select * from articles) where id =.*",
+      "output": [
+        {
+          "type": "tag",
+          "value": "$1"
+        },
+        {
+          "type": "log"
+        }
+      ]
+    }
+  ]
+}
+```         
+
+This would shorten the `db.statement` tag to `select * from articles`, 
+but keep the original statement in a log entry with the same field key (`db.statement`).
+
+The next example uses the same mechanism - using multiple output to have a shorter version somewhere else.
+In this case, it is a different tag - and you can specify the output tag using `key`.   
+
+```json
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "http.url",
+      "valueRegex": "(https?).*",
+      "output": [
+        {
+          "type": "tag",
+          "key": "http.protocol",
+          "value": "$1"
+        }, 
+        {
+          "type": "tag"
+        }
+      ]
+    }
+  ]
+}
+```                           

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/RegexSpanRuleMatcher.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/RegexSpanRuleMatcher.java
@@ -1,0 +1,32 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexSpanRuleMatcher implements SpanRuleMatcher {
+
+  private final Pattern pattern;
+
+  public RegexSpanRuleMatcher(String valueRegex) {
+    this.pattern = Pattern.compile(valueRegex);
+  }
+
+  @Override
+  public SpanRuleMatch match(final Object value) {
+    final Matcher matcher = pattern.matcher(value.toString());
+
+    if (!matcher.matches()) {
+      return null;
+    }
+
+    return new SpanRuleMatch() {
+      @Override
+      public Object getValue(Object outputExpression) {
+        if (outputExpression != null) {
+          return matcher.replaceAll(outputExpression.toString());
+        }
+        return value;
+      }
+    };
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanCustomizer.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanCustomizer.java
@@ -1,0 +1,9 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public interface SpanCustomizer {
+  void setTag(String key, Object value);
+
+  void addLogField(String key, Object value);
+
+  void setOperationName(String name);
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRule.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRule.java
@@ -1,0 +1,33 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import java.util.List;
+
+public class SpanRule {
+  private final SpanRuleType type;
+  private final String key;
+  private final SpanRuleMatcher matcher;
+  private final List<SpanRuleOutput> outputs;
+
+  public SpanRule(SpanRuleMatcher matcher, SpanRuleType type, String key, List<SpanRuleOutput> outputs) {
+    this.matcher = matcher;
+    this.type = type;
+    this.key = key;
+    this.outputs = outputs;
+  }
+
+  public List<SpanRuleOutput> getOutputs() {
+    return outputs;
+  }
+
+  public SpanRuleMatcher getMatcher() {
+    return matcher;
+  }
+
+  public SpanRuleType getType() {
+    return type;
+  }
+
+  public String getKey() {
+    return key;
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleMatch.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleMatch.java
@@ -1,0 +1,5 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public interface SpanRuleMatch {
+  Object getValue(Object outputExpression);
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleMatcher.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleMatcher.java
@@ -1,0 +1,8 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public interface SpanRuleMatcher {
+  /**
+   * returns {@code null} if not matched
+   */
+  SpanRuleMatch match(Object value);
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleOutput.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleOutput.java
@@ -1,0 +1,25 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public class SpanRuleOutput {
+  private final SpanRuleType type;
+  private final String key;
+  private final Object value;
+
+  public SpanRuleOutput(SpanRuleType type, String key, Object value) {
+    this.type = type;
+    this.key = key;
+    this.value = value;
+  }
+
+  public SpanRuleType getType() {
+    return type;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleParser.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleParser.java
@@ -1,0 +1,94 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import io.opentracing.contrib.specialagent.Level;
+import io.opentracing.contrib.specialagent.Logger;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class SpanRuleParser {
+  private final Logger logger = Logger.getLogger(SpanRuleParser.class);
+
+  public Map<String, SpanRules> parseRules(InputStream inputStream) {
+    Map<String, SpanRules> result = new LinkedHashMap<>();
+
+    try {
+      try {
+        JsonObject root = JsonParser.object().from(inputStream);
+
+        for (String key : root.keySet()) {
+          String subject = key + ": ";
+          try {
+            JsonArray ruleEntry = Objects.requireNonNull(root.getArray(key), subject + "not an array");
+            result.put(key, new SpanRules(parseRules(ruleEntry, subject)));
+          } catch (Exception e) {
+            logger.log(Level.WARNING, "could not parse customizer rules for " + key, e);
+          }
+        }
+      } finally {
+        inputStream.close();
+      }
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "could not parse customizer rules", e);
+    }
+    return result;
+  }
+
+  List<SpanRule> parseRules(JsonArray jsonRules, String subject) {
+    List<SpanRule> rules = new ArrayList<>();
+
+    for (int i = 0; i < jsonRules.size(); i++) {
+      String ruleSubject = subject + "rule " + i + ": ";
+      JsonObject jsonRule = Objects.requireNonNull(jsonRules.getObject(i), ruleSubject + "not an object");
+      rules.add(parseRule(jsonRule, ruleSubject));
+    }
+
+    return rules;
+  }
+
+  private SpanRule parseRule(JsonObject jsonRule, String subject) {
+    SpanRuleType type = parseType(jsonRule.getString("type"), subject);
+    String key = jsonRule.getString("key");
+
+    List<SpanRuleOutput> outputs = new ArrayList<>();
+    JsonArray jsonOutputs = jsonRule.getArray("output");
+    if (jsonOutputs != null) {
+      for (int i = 0; i < jsonOutputs.size(); i++) {
+        outputs.add(parseOutput(jsonOutputs, i, subject + "output " + i + ": "));
+      }
+    }
+
+    SpanRule rule = new SpanRule(parseMatcher(jsonRule), type, key, outputs);
+    new SpanRuleValidator().validateRule(rule, subject);
+    return rule;
+  }
+
+  private SpanRuleOutput parseOutput(JsonArray jsonOutputs, int i, String subject) {
+    JsonObject jsonOutput = Objects.requireNonNull(jsonOutputs.getObject(i), subject + "not an object");
+    return new SpanRuleOutput(
+      parseType(jsonOutput.getString("type"), subject),
+      jsonOutput.getString("key"),
+      jsonOutput.get("value")
+    );
+  }
+
+  private SpanRuleMatcher parseMatcher(JsonObject jsonRule) {
+    String valueRegex = jsonRule.getString("valueRegex");
+    if (valueRegex != null) {
+      return new RegexSpanRuleMatcher(valueRegex);
+    } else {
+      return new PlainSpanRuleMatcher(jsonRule.get("value"));
+    }
+  }
+
+  private SpanRuleType parseType(String type, String subject) {
+    return SpanRuleType.valueOf(Objects.requireNonNull(type,  subject + "type is null"));
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleParser.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleParser.java
@@ -82,10 +82,14 @@ public class SpanRuleParser {
   private SpanRuleMatcher parseMatcher(JsonObject jsonRule) {
     String valueRegex = jsonRule.getString("valueRegex");
     if (valueRegex != null) {
-      return new RegexSpanRuleMatcher(valueRegex);
+      return regexSpanRuleMatcher(valueRegex);
     } else {
       return new PlainSpanRuleMatcher(jsonRule.get("value"));
     }
+  }
+
+  protected RegexSpanRuleMatcher regexSpanRuleMatcher(String valueRegex) {
+    return new RegexSpanRuleMatcher(valueRegex);
   }
 
   private SpanRuleType parseType(String type, String subject) {

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleType.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleType.java
@@ -1,0 +1,24 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public enum SpanRuleType {
+  log {
+    @Override
+    void apply(SpanCustomizer customizer, String key, Object value) {
+      customizer.addLogField(key, value);
+    }
+  },
+  operationName {
+    @Override
+    void apply(SpanCustomizer customizer, String key, Object value) {
+      customizer.setOperationName(value.toString());
+    }
+  },
+  tag {
+    @Override
+    void apply(SpanCustomizer customizer, String key, Object value) {
+      customizer.setTag(key, value);
+    }
+  };
+
+  abstract void apply(SpanCustomizer customizer, String key, Object value);
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleValidator.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRuleValidator.java
@@ -1,0 +1,58 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+public class SpanRuleValidator {
+  public void validateRule(SpanRule rule, String subject) {
+    switch (rule.getType()) {
+      case log:
+        break;
+      case operationName:
+        validateOperationName(rule, subject);
+        break;
+      case tag:
+        validateTag(rule, subject);
+        break;
+    }
+
+    for (int i = 0; i < rule.getOutputs().size(); i++) {
+      SpanRuleOutput output = rule.getOutputs().get(i);
+      validateOutputKey(rule.getType(), rule.getKey(), output.getType(), output.getKey(),
+        subject + "output " + i + ": ");
+    }
+  }
+
+  private void validateOperationName(SpanRule rule, String subject) {
+    if (rule.getKey() != null) {
+      throw new IllegalStateException(subject + "key for operationName must be null");
+    }
+  }
+
+  private void validateTag(SpanRule rule, String subject) {
+    if (rule.getKey() == null) {
+      throw new IllegalStateException(subject + "tag without a key is not allowed");
+    }
+  }
+
+  private void validateOutputKey(SpanRuleType matchType, String matchKey,
+                                 SpanRuleType outputType, String outputKey, String subject) {
+    boolean noKeyProvided = matchKey == null && outputKey == null;
+
+    switch (outputType) {
+      case log:
+        boolean matchLogEvent = matchType == SpanRuleType.log && matchKey == null;
+        if (!matchLogEvent && noKeyProvided) {
+          throw new IllegalStateException(subject + "missing output key for log fields");
+        }
+        break;
+      case operationName:
+        if (outputKey != null) {
+          throw new IllegalStateException(subject + "operationName cannot have output key");
+        }
+        break;
+      case tag:
+        if (noKeyProvided) {
+          throw new IllegalStateException(subject + "missing output key for tag");
+        }
+        break;
+    }
+  }
+}

--- a/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRules.java
+++ b/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/SpanRules.java
@@ -1,0 +1,113 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SpanRules {
+  private Map<String, List<SpanRule>> rulesByKey = new LinkedHashMap<>();
+
+  public SpanRules(List<SpanRule> rules) {
+    for (SpanRule rule : rules) {
+      String key = rule.getKey();
+      List<SpanRule> list = rulesByKey.get(key);
+      if (list == null) {
+        list = new ArrayList<>();
+        rulesByKey.put(key, list);
+      }
+      list.add(rule);
+    }
+  }
+
+  public void processOperationName(String operationName, SpanCustomizer customizer) {
+    if (!processRules(SpanRuleType.operationName, null, operationName, customizer)) {
+      customizer.setOperationName(operationName);
+    }
+  }
+
+  public void setTag(String key, Object value, SpanCustomizer customizer) {
+    if (!processRules(SpanRuleType.tag, key, value, customizer)) {
+      customizer.setTag(key, value);
+    }
+  }
+
+  public void log(String event, LogEventCustomizer builder) {
+    if (!processRules(SpanRuleType.log, null, event, builder)) {
+      builder.log(event);
+    }
+  }
+
+  public void log(Map<String, ?> fields, LogFieldCustomizer builder) {
+    for (Map.Entry<String, ?> entry : fields.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+
+      for (SpanRule rule : getSpanRules(key)) {
+        if (rule.getType() != SpanRuleType.log) {
+          continue;
+        }
+
+        SpanRuleMatch match = rule.getMatcher().match(value);
+        if (match != null) {
+          replaceLog(fields, rule, match, builder);
+          return;
+        }
+      }
+    }
+
+    //nothing matched
+    builder.log(fields);
+  }
+
+  private List<SpanRule> getSpanRules(String key) {
+    List<SpanRule> rules = rulesByKey.get(key);
+    if (rules == null) {
+      return Collections.emptyList();
+    }
+    return rules;
+  }
+
+  private void replaceLog(Map<String, ?> fields, SpanRule matchedRule, SpanRuleMatch match, LogFieldCustomizer builder) {
+
+    for (Map.Entry<String, ?> entry : fields.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+
+      if (key.equals(matchedRule.getKey())) {
+        processMatch(matchedRule, match, builder);
+      } else {
+        if (!processRules(SpanRuleType.log, key, value, builder)) {
+          builder.addLogField(key, value);
+        }
+      }
+    }
+
+    builder.finish();
+  }
+
+  private boolean processRules(SpanRuleType type, String key, Object value, SpanCustomizer customizer) {
+    for (SpanRule rule : getSpanRules(key)) {
+      if (rule.getType() != type) {
+        continue;
+      }
+
+      SpanRuleMatch match = rule.getMatcher().match(value);
+      if (match != null) {
+        processMatch(rule, match, customizer);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void processMatch(SpanRule rule, SpanRuleMatch match, SpanCustomizer customizer) {
+    for (SpanRuleOutput output : rule.getOutputs()) {
+      Object outputValue = match.getValue(output.getValue());
+      String key = output.getKey() != null ? output.getKey() : rule.getKey();
+      output.getType().apply(customizer, key, outputValue);
+    }
+  }
+
+}

--- a/opentracing-specialagent-util/src/test/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracerScenario.java
+++ b/opentracing-specialagent-util/src/test/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracerScenario.java
@@ -1,0 +1,167 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public enum CustomizableTracerScenario {
+  complex {
+    @Override
+    void play(Tracer tracer) {
+      Span span = tracer.buildSpan("operation")
+        .withTag("t1", "tv1")
+        .withTag("t2", 1)
+        .withTag("t3", true)
+        .start();
+
+      span.log(1, "event");
+      span.log(2, logOrTagMap());
+      span.finish();
+    }
+  },
+  logEvent {
+    @Override
+    void play(Tracer tracer) {
+      Span span = tracer.buildSpan("operation").start();
+      span.log("event");
+      span.finish();
+    }
+  },
+  logEventTimestamp {
+    @Override
+    void play(Tracer tracer) {
+      Span span = tracer.buildSpan("operation").start();
+      span.log(1, "event");
+      span.finish();
+    }
+  },
+  logFields {
+    @Override
+    void play(Tracer tracer) {
+      Span span = tracer.buildSpan("operation").start();
+      span.log(Collections.singletonMap("key", "value"));
+      span.finish();
+    }
+  },
+  logFieldsTimestamp {
+    @Override
+    void play(Tracer tracer) {
+      logFieldsSpan(tracer, Collections.singletonMap("key", "value"));
+    }
+  },
+  logFieldsTypes {
+    @Override
+    void play(Tracer tracer) {
+      logFieldsSpan(tracer, logOrTagMap());
+    }
+  },
+  logFieldsNumber {
+    @Override
+    void play(Tracer tracer) {
+      logFieldsSpan(tracer, Collections.singletonMap("key", 1));
+      logFieldsSpan(tracer, Collections.singletonMap("key", 1L));
+      logFieldsSpan(tracer, Collections.singletonMap("key", 1f));
+      logFieldsSpan(tracer, Collections.singletonMap("key", 1d));
+    }
+  },
+  operationName {
+    @Override
+    void play(Tracer tracer) {
+      //will keep the operation name even if no output matches
+      tracer.buildSpan("operation").start().finish();
+    }
+  },
+  operationName2Spans {
+    @Override
+    void play(Tracer tracer) {
+      tracer.buildSpan("newOperation").start().finish();
+
+      //should behave the same when we set the operation name later
+      Span late = tracer.buildSpan("oldOperation").start();
+      late.setOperationName("newOperation");
+      late.finish();
+    }
+  },
+  operationNameLate {
+    @Override
+    void play(Tracer tracer) {
+      Span late = tracer.buildSpan("operation").start();
+      //and it's even possible to ignore setOperationName completely
+      late.setOperationName("strange");
+      late.finish();
+    }
+  },
+  tag {
+    @Override
+    void play(Tracer tracer) {
+      tracer.buildSpan("operation").withTag("key", "value").start().finish();
+    }
+  },
+  tag2Spans {
+    @Override
+    void play(Tracer tracer) {
+      tracer.buildSpan("operation").withTag("key", "value").start().finish();
+
+      //should behave the same when we set the tag later
+      Span late = tracer.buildSpan("operation").start();
+      late.setTag("key", "value");
+      late.finish();
+    }
+  },
+  tagHttpUrl {
+    @Override
+    void play(Tracer tracer) {
+      tracer.buildSpan("operation").withTag(Tags.HTTP_URL, "http://example.com").start().finish();
+
+      Span span = tracer.buildSpan("operation").start();
+      span.setTag(Tags.HTTP_URL, "http://example.com");
+      span.finish();
+    }
+  },
+  tagNumber{
+    @Override
+    void play(Tracer tracer) {
+      tracer.buildSpan("operation").withTag("key", 1).start().finish();
+      tracer.buildSpan("operation").withTag("key", 1L).start().finish();
+      tracer.buildSpan("operation").withTag("key", 1f).start().finish();
+      tracer.buildSpan("operation").withTag("key", 1d).start().finish();
+    }
+  },
+  tagTypes {
+    @Override
+    void play(Tracer tracer) {
+      tracer.buildSpan("operation")
+        .withTag("k1", "v1")
+        .withTag("k2", 1)
+        .withTag("k3", false)
+        .start().finish();
+
+      //should behave the same when we set the tag later
+      Span late = tracer.buildSpan("operation").start();
+      late.setTag("k1", "v1");
+      late.setTag("k2", 1);
+      late.setTag("k3", false);
+      late.finish();
+    }
+  };
+
+  private static void logFieldsSpan(Tracer tracer, Map<String, ? extends Object> fields) {
+    Span span = tracer.buildSpan("operation").start();
+    span.log(1, fields);
+    span.finish();
+  }
+
+  private static Map<String, Object> logOrTagMap() {
+    LinkedHashMap<String, Object> log = new LinkedHashMap<>();
+    log.put("k1", "v1");
+    log.put("k2", 1);
+    log.put("k3", false);
+    return log;
+  }
+
+  abstract void play(Tracer tracer);
+}

--- a/opentracing-specialagent-util/src/test/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracerTest.java
+++ b/opentracing-specialagent-util/src/test/java/io/opentracing/contrib/specialagent/tracer/CustomizableTracerTest.java
@@ -1,0 +1,144 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class CustomizableTracerTest {
+
+  private final File file;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Object[] data() {
+    return new File("src/test/resources/spanCustomizer").listFiles();
+  }
+
+  public CustomizableTracerTest(File file) {
+    this.file = file;
+  }
+
+  @Test
+  public void test() throws Exception {
+    JsonObject root;
+    try (FileInputStream stream = new FileInputStream(file)) {
+      root = JsonParser.object().from(stream);
+    }
+
+    JsonArray jsonRules = Objects.requireNonNull(root.getArray("rules"));
+
+    String expectedError = root.getString("expectedError");
+    if (expectedError != null) {
+      try {
+        parseRules(jsonRules);
+      } catch (IllegalStateException e) {
+        assertEquals(expectedError, e.getMessage());
+        return;
+      }
+      Assert.fail("no exception thrown");
+    } else {
+      playScenario(root, parseRules(jsonRules));
+    }
+  }
+
+  private SpanRules parseRules(JsonArray jsonRules) {
+    return new SpanRules(new SpanRuleParser().parseRules(jsonRules, "test: "));
+  }
+
+  private void playScenario(JsonObject root, SpanRules rules) {
+    MockTracer mockTracer = new MockTracer();
+    CustomizableTracerScenario scenario = CustomizableTracerScenario.valueOf(root.getString("scenario"));
+    scenario.play(new CustomizableTracer(mockTracer, rules));
+
+    JsonArray expectedSpans = Objects.requireNonNull(root.getArray("expectedSpans"));
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(expectedSpans.size(), spans.size());
+    for (int i = 0; i < spans.size(); i++) {
+      MockSpan span = spans.get(i);
+      String message = "span " + i;
+      JsonObject expectedSpan = Objects.requireNonNull(expectedSpans.getObject(i), message);
+
+      assertEquals(message, Objects.requireNonNull(expectedSpan.getString("operationName")), span.operationName());
+      assertTags(expectedSpan, span, message);
+      assertLogs(expectedSpan, span, message);
+    }
+  }
+
+  private void assertTags(JsonObject expectedSpan, MockSpan span, String message) {
+    JsonObject expectedTags = expectedSpan.getObject("tags");
+    Map<String, Object> tags = span.tags();
+
+    if (expectedTags == null) {
+      assertEquals(message, 0, tags.size());
+      return;
+    }
+
+    for (Map.Entry<String, Object> entry : expectedTags.entrySet()) {
+      String key = entry.getKey();
+      assertEquals(message + " tag " + key, entry.getValue(), tags.get(key));
+    }
+    assertEquals(message, expectedTags.size(), tags.size());
+  }
+
+  private void assertLogs(JsonObject expectedSpan, MockSpan span, String message) {
+    JsonArray expectedLogs = expectedSpan.getArray("logs");
+    List<MockSpan.LogEntry> logEntries = span.logEntries();
+
+    if (expectedLogs == null) {
+      assertEquals(0, logEntries.size());
+      return;
+    }
+    
+    assertEquals(message, expectedLogs.size(), logEntries.size());
+
+    for (int i = 0; i < expectedLogs.size(); i++) {
+      JsonObject expectedLog = Objects.requireNonNull(expectedLogs.getObject(i));
+      assertLog(expectedLog, logEntries.get(i), message + " log " + i);
+    }
+  }
+
+  private void assertLog(JsonObject expectedLog, MockSpan.LogEntry logEntry, String message) {
+    Map<String, ?> fields = logEntry.fields();
+
+    String expectedEvent = expectedLog.getString("event");
+    JsonObject expectedFields = expectedLog.getObject("fields");
+
+    Number number = expectedLog.getNumber("timestampMicros");
+    if (number != null) {
+      assertEquals(message, number.longValue(), logEntry.timestampMicros());
+    }
+
+    int given = 0;
+    if (expectedEvent != null) {
+      given++;
+
+      assertEquals(message, 1, fields.size());
+      assertEquals(message, expectedEvent, fields.get("event"));
+    }
+    if (expectedFields != null) {
+      given++;
+
+      assertEquals(message, expectedFields.size(), fields.size());
+      for (Map.Entry<String, Object> entry : expectedFields.entrySet()) {
+        String key = entry.getKey();
+        assertEquals(message + " key " + key, entry.getValue(), fields.get(key));
+      }
+    }
+    assertEquals(message, 1, given);
+  }
+}

--- a/opentracing-specialagent-util/src/test/java/io/opentracing/contrib/specialagent/tracer/SpanRuleParserTest.java
+++ b/opentracing-specialagent-util/src/test/java/io/opentracing/contrib/specialagent/tracer/SpanRuleParserTest.java
@@ -1,0 +1,33 @@
+package io.opentracing.contrib.specialagent.tracer;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class SpanRuleParserTest {
+
+  private SpanRuleParser parser = new SpanRuleParser();
+
+  @Test
+  public void parseRules() throws FileNotFoundException {
+    Map<String, SpanRules> rules = parser.parseRules(new FileInputStream("src/test/resources/spanRules.json"));
+    assertEquals(1, rules.size());
+    assertEquals("jedis", rules.keySet().iterator().next());
+  }
+
+  @Test
+  public void completeInvalidJson() {
+    assertEquals(0, parser.parseRules(new ByteArrayInputStream("invalid".getBytes())).size());
+  }
+
+  @Test
+  public void oneRuleInvalidJson() {
+    String json = "{\"invalid\": 1, \"jedis\": []}";
+    assertEquals(1, parser.parseRules(new ByteArrayInputStream(json.getBytes())).size());
+  }
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_logFields_withoutOutputKey.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_logFields_withoutOutputKey.json
@@ -1,0 +1,13 @@
+{
+  "expectedError": "test: rule 0: output 0: missing output key for log fields",
+  "rules": [
+    {
+      "type": "operationName",
+      "output": [
+        {
+          "type": "log"
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_operationName_withKey.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_operationName_withKey.json
@@ -1,0 +1,9 @@
+{
+  "expectedError": "test: rule 0: key for operationName must be null",
+  "rules": [
+    {
+      "type": "operationName",
+      "key": "k1"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_operationName_withOutputKey.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_operationName_withOutputKey.json
@@ -1,0 +1,14 @@
+{
+  "expectedError": "test: rule 0: output 0: operationName cannot have output key",
+  "rules": [
+    {
+      "type": "operationName",
+      "output": [
+        {
+          "type": "operationName",
+          "key": "key"
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_tag_withoutKey.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_tag_withoutKey.json
@@ -1,0 +1,8 @@
+{
+  "expectedError": "test: rule 0: tag without a key is not allowed",
+  "rules": [
+    {
+      "type": "tag"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_tag_withoutOutputKey.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/error_tag_withoutOutputKey.json
@@ -1,0 +1,13 @@
+{
+  "expectedError": "test: rule 0: output 0: missing output key for tag",
+  "rules": [
+    {
+      "type": "operationName",
+      "output": [
+        {
+          "type": "tag"
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logEvent_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logEvent_multiOutput.json
@@ -1,0 +1,34 @@
+{
+  "scenario": "logEventTimestamp",
+  "rules": [
+    {
+      "type": "log",
+      "output": [
+        {
+          "type": "log"
+        },
+        {
+          "type": "operationName"
+        },
+        {
+          "type": "tag",
+          "key": "key"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "event",
+      "tags": {
+        "key": "event"
+      },
+      "logs": [
+        {
+          "event": "event",
+          "timestampMicros": 1
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logEvent_simple.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logEvent_simple.json
@@ -1,0 +1,23 @@
+{
+  "scenario": "logEvent",
+  "rules": [
+    {
+      "type": "log",
+      "output": [
+        {
+          "type": "log"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "logs": [
+        {
+          "event": "event"
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_firstMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_firstMatches.json
@@ -1,0 +1,27 @@
+{
+  "scenario": "logFieldsTypes",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "k1"
+    },
+    {
+      "type": "log",
+      "key": "k1"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "logs": [
+        {
+          "fields": {
+            "k2": 1,
+            "k3": false
+          },
+          "timestampMicros": 1
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_firstMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_firstMatches.json
@@ -10,6 +10,7 @@
       "key": "k1"
     }
   ],
+  "expectedMapAllocations": 1,
   "expectedSpans": [
     {
       "operationName": "operation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_noneMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_noneMatches.json
@@ -1,0 +1,29 @@
+{
+  "scenario": "logFieldsTypes",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "k2"
+    },
+    {
+      "type": "log",
+      "key": "k2",
+      "value": "foo"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "logs": [
+        {
+          "fields": {
+            "k1": "v1",
+            "k2": 1,
+            "k3": false
+          },
+          "timestampMicros": 1
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_secondMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_secondMatches.json
@@ -10,6 +10,7 @@
       "key": "k2"
     }
   ],
+  "expectedMapAllocations": 1,
   "expectedSpans": [
     {
       "operationName": "operation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_secondMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_multiple_secondMatches.json
@@ -1,0 +1,27 @@
+{
+  "scenario": "logFieldsTypes",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "k2"
+    },
+    {
+      "type": "log",
+      "key": "k2"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "logs": [
+        {
+          "fields": {
+            "k1": "v1",
+            "k3": false
+          },
+          "timestampMicros": 1
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_numberMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_blacklist_numberMatches.json
@@ -1,0 +1,24 @@
+{
+  "scenario": "logFieldsNumber",
+  "rules": [
+    {
+      "type": "log",
+      "key": "key",
+      "value": 1
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_multiOutput.json
@@ -1,0 +1,36 @@
+{
+  "scenario": "logFieldsTimestamp",
+  "rules": [
+    {
+      "type": "log",
+      "key": "key",
+      "output": [
+        {
+          "type": "log"
+        },
+        {
+          "type": "operationName"
+        },
+        {
+          "type": "tag"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "value",
+      "tags": {
+        "key": "value"
+      },
+      "logs": [
+        {
+          "fields": {
+            "key": "value"
+          },
+          "timestampMicros": 1
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_multiOutput.json
@@ -17,6 +17,7 @@
       ]
     }
   ],
+  "expectedMapAllocations": 1,
   "expectedSpans": [
     {
       "operationName": "value",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_simple.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_simple.json
@@ -11,6 +11,7 @@
       ]
     }
   ],
+  "expectedMapAllocations": 1,
   "expectedSpans": [
     {
       "operationName": "operation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_simple.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/logFields_simple.json
@@ -1,0 +1,26 @@
+{
+  "scenario": "logFields",
+  "rules": [
+    {
+      "type": "log",
+      "key": "key",
+      "output": [
+        {
+          "type": "log"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "logs": [
+        {
+          "fields": {
+            "key": "value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/noChange.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/noChange.json
@@ -1,0 +1,28 @@
+{
+  "scenario": "complex",
+  "rules": [],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "t1": "tv1",
+        "t2": 1,
+        "t3": true
+      },
+      "logs": [
+        {
+          "event": "event",
+          "timestampMicros": 1
+        },
+        {
+          "fields": {
+            "k1": "v1",
+            "k2": 1,
+            "k3": false
+          },
+          "timestampMicros": 2
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_ignore.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_ignore.json
@@ -1,0 +1,14 @@
+{
+  "scenario": "operationNameLate",
+  "rules": [
+    {
+      "type": "operationName",
+      "value": "strange"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_multiOutput.json
@@ -1,0 +1,50 @@
+{
+  "scenario": "operationName2Spans",
+  "rules": [
+    {
+      "type": "operationName",
+      "value": "newOperation",
+      "output": [
+        {
+          "type": "log",
+          "key": "lop"
+        },
+        {
+          "type": "operationName"
+        },
+        {
+          "type": "tag",
+          "key": "top"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "newOperation",
+      "tags": {
+        "top": "newOperation"
+      },
+      "logs": [
+        {
+          "fields": {
+            "lop": "newOperation"
+          }
+        }
+      ]
+    },
+    {
+      "operationName": "newOperation",
+      "tags": {
+        "top": "newOperation"
+      },
+      "logs": [
+        {
+          "fields": {
+            "lop": "newOperation"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_multiOutput.json
@@ -19,6 +19,8 @@
       ]
     }
   ],
+  "expectedListAllocations": 1,
+  "expectedMapAllocations": 1,
   "expectedSpans": [
     {
       "operationName": "newOperation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_withoutOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/operationName_withoutOutput.json
@@ -1,0 +1,13 @@
+{
+  "scenario": "operationName",
+  "rules": [
+    {
+      "type": "operationName"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist.json
@@ -1,0 +1,14 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_httpUrl.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_httpUrl.json
@@ -1,0 +1,17 @@
+{
+  "scenario": "tagHttpUrl",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "http.url"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_numberMatches.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_numberMatches.json
@@ -1,0 +1,24 @@
+{
+  "scenario": "tagNumber",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "value": 1
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    },
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueMatched.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueMatched.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "valueRegex": "val.*"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueMatched.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueMatched.json
@@ -7,6 +7,7 @@
       "valueRegex": "val.*"
     }
   ],
+  "expectedRegexMatches": 1,
   "expectedSpans": [
     {
       "operationName": "operation"

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueNotMatched.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueNotMatched.json
@@ -1,0 +1,18 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "valueRegex": "var.*"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "key": "value"
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueNotMatched.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_regex_valueNotMatched.json
@@ -7,6 +7,7 @@
       "valueRegex": "var.*"
     }
   ],
+  "expectedRegexMatches": 1,
   "expectedSpans": [
     {
       "operationName": "operation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_valueMatched.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_valueMatched.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "value": "value"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation"
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_valueNotMatched.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_blacklist_valueNotMatched.json
@@ -1,0 +1,18 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "value": "other"
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "key": "value"
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_multiOutput.json
@@ -17,6 +17,7 @@
       ]
     }
   ],
+  "expectedListAllocations": 1,
   "expectedSpans": [
     {
       "operationName": "value",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_multiOutput.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_multiOutput.json
@@ -1,0 +1,48 @@
+{
+  "scenario": "tag2Spans",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "output": [
+        {
+          "type": "log"
+        },
+        {
+          "type": "operationName"
+        },
+        {
+          "type": "tag"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "value",
+      "tags": {
+        "key": "value"
+      },
+      "logs": [
+        {
+          "fields": {
+            "key": "value"
+          }
+        }
+      ]
+    },
+    {
+      "operationName": "value",
+      "tags": {
+        "key": "value"
+      },
+      "logs": [
+        {
+          "fields": {
+            "key": "value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_newKey.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_newKey.json
@@ -1,0 +1,23 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "output": [
+        {
+          "type": "tag",
+          "key": "newKey"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "newKey": "value"
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueNotReplaced.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueNotReplaced.json
@@ -1,0 +1,23 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "valueRegex": "(va.?)ue",
+      "output": [
+        {
+          "type": "tag"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "key": "value"
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueNotReplaced.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueNotReplaced.json
@@ -12,6 +12,7 @@
       ]
     }
   ],
+  "expectedRegexMatches": 1,
   "expectedSpans": [
     {
       "operationName": "operation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueReplaced.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueReplaced.json
@@ -1,0 +1,24 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "valueRegex": "(va.?)ue",
+      "output": [
+        {
+          "type": "tag",
+          "value": "$1?"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "key": "val?"
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueReplaced.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_regex_valueReplaced.json
@@ -13,6 +13,7 @@
       ]
     }
   ],
+  "expectedRegexMatches": 1,
   "expectedSpans": [
     {
       "operationName": "operation",

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_types.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_types.json
@@ -1,0 +1,55 @@
+{
+  "scenario": "tagTypes",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "k1",
+      "value": "v1",
+      "output": [
+        {
+          "type": "tag",
+          "value": "new"
+        }
+      ]
+    },
+    {
+      "type": "tag",
+      "key": "k2",
+      "value": 1,
+      "output": [
+        {
+          "type": "tag",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "tag",
+      "key": "k3",
+      "output": [
+        {
+          "type": "tag",
+          "value": true
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "k1": "new",
+        "k2": 2,
+        "k3": true
+      }
+    },
+    {
+      "operationName": "operation",
+      "tags": {
+        "k1": "new",
+        "k2": 2,
+        "k3": true
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_valueReplaced.json
+++ b/opentracing-specialagent-util/src/test/resources/spanCustomizer/tag_valueReplaced.json
@@ -1,0 +1,23 @@
+{
+  "scenario": "tag",
+  "rules": [
+    {
+      "type": "tag",
+      "key": "key",
+      "output": [
+        {
+          "type": "tag",
+          "value": "new"
+        }
+      ]
+    }
+  ],
+  "expectedSpans": [
+    {
+      "operationName": "operation",
+      "tags": {
+        "key": "new"
+      }
+    }
+  ]
+}

--- a/opentracing-specialagent-util/src/test/resources/spanRules.json
+++ b/opentracing-specialagent-util/src/test/resources/spanRules.json
@@ -1,0 +1,16 @@
+{
+  "jedis": [
+    {
+      "type": "tag",
+      "key": "db.statement",
+      "valueRegex": "(select).*",
+      "output": [
+        {
+          "type": "log",
+          "key": "sql",
+          "value": "$1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
PR for #407 

Features
1. blacklisting of tags, fields in log entries or entire log entries
2. transform values (tag values, log field values or log events)
3. transform log to tag or tag to log
4. for a syntax, see [README](https://github.com/zeitlinger/java-specialagent/blob/customizable-span/opentracing-specialagent-util/src/main/java/io/opentracing/contrib/specialagent/tracer/README.md)

Still missing 

- [ ] [Integration](https://github.com/opentracing-contrib/java-specialagent/pull/415#issuecomment-586982431) into `AgentRule` by @safris 