### PR TITLE
Split CXF rules into server part and client part.

### DIFF
--- a/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfRsClientAgentRule.java
+++ b/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfRsClientAgentRule.java
@@ -1,0 +1,49 @@
+/* Copyright 2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentracing.contrib.specialagent.rule.cxf;
+
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+import java.util.Arrays;
+
+import io.opentracing.contrib.specialagent.AgentRule;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+import net.bytebuddy.utility.JavaModule;
+
+public class CxfRsClientAgentRule extends AgentRule {
+  @Override
+  public Iterable<? extends AgentBuilder> buildAgent(final AgentBuilder builder) throws Exception {
+    return Arrays.asList(
+      builder.type(hasSuperType(named("org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean")))
+        .transform(new Transformer() {
+          @Override
+          public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
+            return builder.visit(Advice.to(CxfRsClientAdvice.class).on(named("createWithValues").or(named("createWebClient"))));
+          }}));
+  }
+
+  public static class CxfRsClientAdvice {
+    @Advice.OnMethodEnter
+    public static void enter(final @Advice.Origin String origin, final @Advice.This Object thiz) {
+      if (isEnabled(CxfRsClientAgentRule.class.getName(), origin))
+        CxfAgentIntercept.addClientTracingFeature(thiz);
+    }
+  }
+}

--- a/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfRsServerAgentRule.java
+++ b/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfRsServerAgentRule.java
@@ -27,36 +27,22 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType.Builder;
 import net.bytebuddy.utility.JavaModule;
 
-public class CxfWsAgentRule extends AgentRule {
+public class CxfRsServerAgentRule extends AgentRule {
   @Override
   public Iterable<? extends AgentBuilder> buildAgent(final AgentBuilder builder) throws Exception {
     return Arrays.asList(
-      builder.type(hasSuperType(named("org.apache.cxf.frontend.ClientFactoryBean")))
+      builder.type(hasSuperType(named("org.apache.cxf.jaxrs.JAXRSServerFactoryBean")))
         .transform(new Transformer() {
           @Override
           public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
-            return builder.visit(Advice.to(CxfWsClientAdvice.class).on(named("create")));
-          }}),
-      builder.type(hasSuperType(named("org.apache.cxf.frontend.ServerFactoryBean")))
-        .transform(new Transformer() {
-          @Override
-          public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
-            return builder.visit(Advice.to(CxfWsServerAdvice.class).on(named("create")));
+            return builder.visit(Advice.to(CxfRsServerAdvice.class).on(named("create")));
           }}));
   }
 
-  public static class CxfWsClientAdvice {
+  public static class CxfRsServerAdvice {
     @Advice.OnMethodEnter
     public static void enter(final @Advice.Origin String origin, final @Advice.This Object thiz) {
-      if (isEnabled(CxfWsAgentRule.class.getName(), origin))
-        CxfAgentIntercept.addClientTracingFeature(thiz);
-    }
-  }
-
-  public static class CxfWsServerAdvice {
-    @Advice.OnMethodEnter
-    public static void enter(final @Advice.Origin String origin, final @Advice.This Object thiz) {
-      if (isEnabled(CxfWsAgentRule.class.getName(), origin))
+      if (isEnabled(CxfRsServerAgentRule.class.getName(), origin))
         CxfAgentIntercept.addServerTracingFeauture(thiz);
     }
   }

--- a/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfWsClientAgentRule.java
+++ b/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfWsClientAgentRule.java
@@ -1,0 +1,49 @@
+/* Copyright 2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentracing.contrib.specialagent.rule.cxf;
+
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+import java.util.Arrays;
+
+import io.opentracing.contrib.specialagent.AgentRule;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+import net.bytebuddy.utility.JavaModule;
+
+public class CxfWsClientAgentRule extends AgentRule {
+  @Override
+  public Iterable<? extends AgentBuilder> buildAgent(final AgentBuilder builder) throws Exception {
+    return Arrays.asList(
+      builder.type(hasSuperType(named("org.apache.cxf.frontend.ClientFactoryBean")))
+        .transform(new Transformer() {
+          @Override
+          public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
+            return builder.visit(Advice.to(CxfWsClientAdvice.class).on(named("create")));
+          }}));
+  }
+
+  public static class CxfWsClientAdvice {
+    @Advice.OnMethodEnter
+    public static void enter(final @Advice.Origin String origin, final @Advice.This Object thiz) {
+      if (isEnabled(CxfWsClientAgentRule.class.getName(), origin))
+        CxfAgentIntercept.addClientTracingFeature(thiz);
+    }
+  }
+}

--- a/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfWsServerAgentRule.java
+++ b/rule/cxf/src/main/java/io/opentracing/contrib/specialagent/rule/cxf/CxfWsServerAgentRule.java
@@ -27,36 +27,22 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType.Builder;
 import net.bytebuddy.utility.JavaModule;
 
-public class CxfRsAgentRule extends AgentRule {
+public class CxfWsServerAgentRule extends AgentRule {
   @Override
   public Iterable<? extends AgentBuilder> buildAgent(final AgentBuilder builder) throws Exception {
     return Arrays.asList(
-      builder.type(hasSuperType(named("org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean")))
+      builder.type(hasSuperType(named("org.apache.cxf.frontend.ServerFactoryBean")))
         .transform(new Transformer() {
           @Override
           public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
-            return builder.visit(Advice.to(CxfRsClientAdvice.class).on(named("createWithValues").or(named("createWebClient"))));
-          }}),
-      builder.type(hasSuperType(named("org.apache.cxf.jaxrs.JAXRSServerFactoryBean")))
-        .transform(new Transformer() {
-          @Override
-          public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
-            return builder.visit(Advice.to(CxfRsServerAdvice.class).on(named("create")));
+            return builder.visit(Advice.to(CxfWsServerAdvice.class).on(named("create")));
           }}));
   }
 
-  public static class CxfRsClientAdvice {
+  public static class CxfWsServerAdvice {
     @Advice.OnMethodEnter
     public static void enter(final @Advice.Origin String origin, final @Advice.This Object thiz) {
-      if (isEnabled(CxfRsAgentRule.class.getName(), origin))
-        CxfAgentIntercept.addClientTracingFeature(thiz);
-    }
-  }
-
-  public static class CxfRsServerAdvice {
-    @Advice.OnMethodEnter
-    public static void enter(final @Advice.Origin String origin, final @Advice.This Object thiz) {
-      if (isEnabled(CxfRsAgentRule.class.getName(), origin))
+      if (isEnabled(CxfWsServerAgentRule.class.getName(), origin))
         CxfAgentIntercept.addServerTracingFeauture(thiz);
     }
   }

--- a/rule/cxf/src/main/resources/otarules.mf
+++ b/rule/cxf/src/main/resources/otarules.mf
@@ -12,5 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-io.opentracing.contrib.specialagent.rule.cxf.CxfRsAgentRule
-io.opentracing.contrib.specialagent.rule.cxf.CxfWsAgentRule
+io.opentracing.contrib.specialagent.rule.cxf.CxfRsServerAgentRule
+io.opentracing.contrib.specialagent.rule.cxf.CxfRsClientAgentRule
+io.opentracing.contrib.specialagent.rule.cxf.CxfWsServerAgentRule
+io.opentracing.contrib.specialagent.rule.cxf.CxfWsClientAgentRule


### PR DESCRIPTION
Split CXF rules into server part and client part in case they can be enabled or disabled separately. Some cases, servlet tracing filter will be used instead of CXF server tracing.