### PR TITLE
turns on mule jdk 8 itest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -399,11 +399,11 @@ jobs:
     jdk: openjdk11
     install: true
     script: travis_retry bash -c "mvn -e -B -P test -pl test/mongo-driver -amd integration-test || (mvn -e -B -P test -pl test/mongo-driver -amd -Dexclude=$PURGE_EXCLUDE dependency:purge-local-repository && false)"
-#  - name: "Mule 4 [openjdk8]"
-#    stage: test
-#    jdk: openjdk8
-#    install: true
-#    script: travis_retry bash -c "mvn -e -B -P test -pl test/mule -amd integration-test || (mvn -e -B -P test -pl test/mule -amd -Dexclude=$PURGE_EXCLUDE dependency:purge-local-repository && false)"
+  - name: "Mule 4 [openjdk8]"
+    stage: test
+    jdk: openjdk8
+    install: true
+    script: travis_retry bash -c "mvn -e -B -P test -pl test/mule -amd integration-test || (mvn -e -B -P test -pl test/mule -amd -Dexclude=$PURGE_EXCLUDE dependency:purge-local-repository && false)"
 #  - name: "Mule 4 [openjdk11]" # This is commented out, because Mule 4 tests does not run on the openjdk11 ver on travis
 #    stage: test
 #    jdk: openjdk11


### PR DESCRIPTION
I locally ran the tests on the commit before these tests being turned off and they passed. I'm checking to see if they pass with on the latest state also...