### PR TITLE
removes mule-4 jdk11 override

### DIFF
--- a/test/mule/mule-4-app/pom.xml
+++ b/test/mule/mule-4-app/pom.xml
@@ -29,6 +29,33 @@
   <properties>
     <exec.skip>true</exec.skip>
   </properties>
+  <profiles>
+    <profile>
+      <id>jdk11-compat</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <!-- This could be a bug with Mule 4 class loading mechanism behaving differently between
+      JDK 1.8 and 11, or an oversight on mule-4-artifact-module instrumentation. To be determined... -->
+      <dependencies>
+        <dependency>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-noop</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-util</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>

--- a/test/mule/mule-4.2.2/src/test/java/io/opentracing/contrib/specialagent/test/Mule4ContainerITest.java
+++ b/test/mule/mule-4.2.2/src/test/java/io/opentracing/contrib/specialagent/test/Mule4ContainerITest.java
@@ -21,11 +21,6 @@ public class Mule4ContainerITest {
   private static final String MULE_HOME = "/src/test/mule-home";
 
   public static void main(final String[] args) throws Exception {
-    if (!System.getProperty("java.version").startsWith("1.8.")) {
-      System.err.println("This test is not working: https://github.com/opentracing-contrib/java-specialagent/issues/405");
-      return;
-    }
-
     final String homeDir = new File("").getAbsolutePath() + MULE_HOME;
     final Mule4ContainerITest lock = new Mule4ContainerITest();
     System.setProperty(MuleSystemProperties.MULE_SIMPLE_LOG, "true");


### PR DESCRIPTION
It turns out that JDK 11 runs for mule-4 integration tests were being skipped from the test itself, so the earlier ci run was a false positive. After removing the override and working through the errors found it seems that there's some different class loading behaviour between mule with 1.8 and 11. Some `provided` scopes fixed this. You can skip the next paragraphs if you don't care about the details.

When using mule 4.2.2 runtime with JDK 11, if the test application has opentracing dependencies compiled-in that the instrumentation rules will need then the class linking seems to fall apart. I've worked around this by declaring those dependencies as `provided` to the test application. This could be a bug with mule 4.2.2 specifically or an opportunity for enhancing the mule-4-artifact-module instrumentation (deals with classloading).

This should not be an issue in a regular application development scenario. Applications that do not use SpecialAgent are obviously not affected, and those that do would probably do so through a custom connector that should just depend on core libraries and declare those as provided.