### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ For the development of <ins>[Integration Rules](#64-integration-rule)</ins>, ple
 | Java Thread [`java.lang.Thread`] | [`thread`][thread] | 1.0 | 11 |
 | HttpURLConnection [`java.net.HttpURLConnection`] | [`httpurlconnection`][httpurlconnection] | 1.1 | 11 |
 | [JAX-RS Client](https://github.com/opentracing-contrib/java-jaxrs) | [`jax-rs`][jaxrs] | 2.0 | LATEST |
-| [Jedis Client](https://github.com/opentracing-contrib/java-redis-client/tree/master/opentracing-redis-jedis) | [`jedis`][jedis] | 2.7.0 | 3.1.0 |
+| [Jedis Client](https://github.com/opentracing-contrib/java-redis-client/tree/master/opentracing-redis-jedis) | [`jedis`][jedis] | 2.7.0 | 3.3.0 |
 | [Kafka Client](https://github.com/opentracing-contrib/java-kafka-client) | [`kafka:client`][kafka-client] | 1.1.0 | LATEST |
 | [Kafka Streams](https://github.com/opentracing-contrib/java-kafka-client) | [`kafka:streams`][kafka-streams] | 1.1.0 | LATEST |
 | [Lettuce Client](https://github.com/opentracing-contrib/java-redis-client/tree/master/opentracing-redis-lettuce) | [`lettuce`][lettuce] | 5.0.0.RELEASE | LATEST |


### PR DESCRIPTION
Now, jedis client already upgrade to 3.3.0. see [https://github.com/opentracing-contrib/java-redis-client/pull/53](https://github.com/opentracing-contrib/java-redis-client/pull/53)