### PR TITLE
Duncan/add rule/quartz

### DIFF
--- a/opentracing-specialagent/pom.xml
+++ b/opentracing-specialagent/pom.xml
@@ -491,6 +491,13 @@
           <optional>true</optional>
           <scope>provided</scope>
         </dependency>
+        <dependency>
+          <groupId>io.opentracing.contrib.specialagent.rule</groupId>
+          <artifactId>quartz</artifactId>
+          <version>${project.version}</version>
+          <optional>true</optional>
+          <scope>provided</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/rule/pom.xml
+++ b/rule/pom.xml
@@ -97,6 +97,7 @@
         <module>pulsar-functions</module>
         <module>dynamic</module>
         <module>cxf</module>
+        <module>quartz</module>
       </modules>
       <build>
         <resources>

--- a/rule/quartz/README.md
+++ b/rule/quartz/README.md
@@ -1,0 +1,11 @@
+# SpecialAgent Rule for Quartz Scheduler
+
+**Rule Name:** `org.quartz-scheduler:quartz`
+
+## Compatibility
+
+```xml
+<groupId>org.quartz-scheduler</groupId>
+<artifactId>quartz</artifactId>
+<version>[2.0.0,LATEST]</version>
+```

--- a/rule/quartz/pom.xml
+++ b/rule/quartz/pom.xml
@@ -1,0 +1,42 @@
+<!--
+  Copyright 2019 The OpenTracing Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.opentracing.contrib.specialagent.rule</groupId>
+    <artifactId>rule</artifactId>
+    <version>1.7.5-SNAPSHOT</version>
+  </parent>
+  <artifactId>quartz</artifactId>
+  <name>SpecialAgent Rule for quartz</name>
+  <properties>
+    <sa.rule.name>quartz</sa.rule.name>
+    <min.version>2.0.0</min.version>
+    <passCompatibility>org.quartz-scheduler:quartz:2.0.0</passCompatibility>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>${min.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/rule/quartz/pom.xml
+++ b/rule/quartz/pom.xml
@@ -24,7 +24,7 @@
     <version>1.7.5-SNAPSHOT</version>
   </parent>
   <artifactId>quartz</artifactId>
-  <name>SpecialAgent Rule for quartz</name>
+  <name>SpecialAgent Rule for Quartz</name>
   <properties>
     <sa.rule.name>quartz</sa.rule.name>
     <min.version>2.0.0</min.version>
@@ -37,6 +37,12 @@
       <version>${min.version}</version>
       <optional>true</optional>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/rule/quartz/src/main/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzJobBeanAgentRule.java
+++ b/rule/quartz/src/main/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzJobBeanAgentRule.java
@@ -1,0 +1,52 @@
+/* Copyright 2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentracing.contrib.specialagent.rule.quartz;
+
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+import io.opentracing.contrib.specialagent.AgentRule;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+import net.bytebuddy.utility.JavaModule;
+
+public class QuartzJobBeanAgentRule extends AgentRule {
+    @Override
+    public AgentBuilder buildAgentChainedGlobal1(final AgentBuilder builder) {
+        return builder
+                .type(hasSuperType(named("org.quartz.Job")).and(not(isInterface())))
+                .transform(new Transformer() {
+                    @Override
+                    public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
+                        return builder.visit(advice(typeDescription).to(QuartzJobBeanAgentRule.class).on(named("execute")));
+                    }
+                });
+    }
+
+    @Advice.OnMethodEnter
+    public static void enter(final @ClassName String className, final @Advice.Origin String origin, final @Advice.This Object thiz, final @Advice.Argument(value = 0) Object arg) {
+        if (isAllowed(className, origin))
+            QuartzjobAgentIntercept.enter(thiz, arg);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
+    public static void exit(final @ClassName String className, final @Advice.Origin String origin, final @Advice.Thrown Throwable thrown) {
+        if (isAllowed(className, origin))
+            QuartzjobAgentIntercept.exit(thrown);
+    }
+}

--- a/rule/quartz/src/main/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzjobAgentIntercept.java
+++ b/rule/quartz/src/main/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzjobAgentIntercept.java
@@ -1,0 +1,56 @@
+/* Copyright 2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentracing.contrib.specialagent.rule.quartz;
+
+import io.opentracing.*;
+import io.opentracing.contrib.specialagent.LocalSpanContext;
+import io.opentracing.contrib.specialagent.OpenTracingApiUtil;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+import org.quartz.JobExecutionContext;
+
+public class QuartzjobAgentIntercept {
+  static final String COMPONENT_NAME = "quartz-job";
+
+  public static void enter(final Object thiz, final Object args) {
+
+    JobExecutionContext jobExecutionContext = (JobExecutionContext)args;
+
+    final Tracer tracer = GlobalTracer.get();
+    final Span span = tracer
+            .buildSpan("quartz:" + jobExecutionContext.getJobDetail().getKey().getName())
+            .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME)
+            .withTag("class", thiz.getClass().getName())
+            .withTag("name", jobExecutionContext.getJobDetail().getKey().getName())
+            .withTag("group", jobExecutionContext.getJobDetail().getKey().getGroup())
+            .start();
+
+    final Scope scope = tracer.activateSpan(span);
+    LocalSpanContext.set(COMPONENT_NAME, span, scope);
+  }
+
+  public static void exit(final Throwable thrown) {
+    final LocalSpanContext context = LocalSpanContext.get(COMPONENT_NAME);
+    if (context == null)
+      return;
+
+    if (thrown != null)
+      OpenTracingApiUtil.setErrorTag(context.getSpan(), thrown);
+
+    context.closeAndFinish();
+  }
+
+}

--- a/rule/quartz/src/main/resources/otarules.mf
+++ b/rule/quartz/src/main/resources/otarules.mf
@@ -1,0 +1,15 @@
+# Copyright 2019 The OpenTracing Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+io.opentracing.contrib.specialagent.rule.quartz.QuartzJobBeanAgentRule

--- a/rule/quartz/src/test/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzJobTest.java
+++ b/rule/quartz/src/test/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzJobTest.java
@@ -1,0 +1,40 @@
+package io.opentracing.contrib.specialagent.rule.quartz;
+
+
+import io.opentracing.contrib.specialagent.AgentRunner;
+import io.opentracing.contrib.specialagent.TestUtil;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AgentRunner.class)
+public class QuartzJobTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+    }
+
+    @Test
+    public void test(final MockTracer tracer) {
+
+
+        await().atMost(10, TimeUnit.SECONDS).until(TestUtil.reportedSpansSize(tracer), greaterThanOrEqualTo(1));
+        final List<MockSpan> spans = tracer.finishedSpans();
+        assertTrue(spans.size() >= 1);
+        for (final MockSpan span : spans) {
+            assertEquals("quartz-job", span.tags().get(Tags.COMPONENT.getKey()));
+        }
+    }
+
+}

--- a/rule/quartz/src/test/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzJobTest.java
+++ b/rule/quartz/src/test/java/io/opentracing/contrib/specialagent/rule/quartz/QuartzJobTest.java
@@ -6,9 +6,12 @@ import io.opentracing.contrib.specialagent.TestUtil;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.quartz.*;
+import org.quartz.impl.StdSchedulerFactory;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -17,23 +20,47 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
 
 @RunWith(AgentRunner.class)
 public class QuartzJobTest {
 
+    static Scheduler scheduler = null;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
+        scheduler = StdSchedulerFactory.getDefaultScheduler();
+        scheduler.start();
     }
 
     @Test
-    public void test(final MockTracer tracer) {
-
-
+    public void test(final MockTracer tracer) throws SchedulerException {
+        JobDetail job = newJob(TestJob.class)
+                .withIdentity("job1", "group1")
+                .build();
+        Trigger trigger = newTrigger()
+                .withIdentity("trigger1", "group1")
+                .startNow()
+                .build();
+        scheduler.scheduleJob(job, trigger);
         await().atMost(10, TimeUnit.SECONDS).until(TestUtil.reportedSpansSize(tracer), greaterThanOrEqualTo(1));
         final List<MockSpan> spans = tracer.finishedSpans();
         assertTrue(spans.size() >= 1);
         for (final MockSpan span : spans) {
             assertEquals("quartz-job", span.tags().get(Tags.COMPONENT.getKey()));
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        scheduler.start();
+    }
+
+    public static class TestJob implements Job {
+        @Override
+        public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+            System.out.println("test job.");
         }
     }
 


### PR DESCRIPTION
Hi @safris, because the OpenTelemetry is not ready for production envs yet, we chose OpenTracing in our production env. 
But some components is not yet supported by java-specialagent. So I implemented some instruments that we need. Here is the instrument for Quartz job, I think you bros can pick it up into the rules.

Besides, I had implemented spring-rabbit:[1.6.0.RELEASE,1.6.11.RELEASE] and okhttp:[2.1.0,3.0.0). If you are intested, i will make more prs.

 