### PR TITLE
Fixes dependency on broken OpenTelemetry bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -660,7 +660,7 @@
       <dependency>
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentelemetry-bridge</artifactId>
-        <version>0.2.0</version>
+        <version>0.4.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Proposed solution to #607.

Version 0.2.0 of `opentelemetry-bridge` contains a bug regarding address port validation (opentracing-contrib/java-opentelemetry-bridge#1), which has been fixed in version 0.4.0 (opentracing-contrib/java-opentelemetry-bridge#2).